### PR TITLE
Move postConstruct calls to a second post-resolution pass

### DIFF
--- a/leaf.go
+++ b/leaf.go
@@ -149,11 +149,6 @@ func (l *leaf) resolveDependencies(tree *Tree) {
 			l.setDependency(tree, name, dep)
 		}
 	}
-
-	// All resolved
-	if l.dependenciesResolved() {
-		l.callPostConstruct()
-	}
 }
 
 // setDependency sets a dependency in the leaf

--- a/leaf_test.go
+++ b/leaf_test.go
@@ -99,18 +99,6 @@ func TestResolveDependencies(t *testing.T) {
 		So(fLeaf.resolvedDependencies, ShouldHaveLength, 1)
 		So(fLeaf.unresolvedDependencies, ShouldHaveLength, 0)
 	})
-
-	Convey("Calls PostConstruct when complete", t, func() {
-
-		f := &foo{}
-		b := &bar{}
-
-		fLeaf := newLeaf(f)
-		bLeaf := newLeaf(b)
-
-		fLeaf.resolveDependencies(NewTree().add(fLeaf).add(bLeaf))
-		So(f.pcCalled, ShouldBeTrue)
-	})
 }
 
 func TestHasAlias(t *testing.T) {

--- a/tree.go
+++ b/tree.go
@@ -32,6 +32,8 @@ func (t *Tree) AddNamedLeaf(name string, value interface{}) *Tree {
 
 // Grow loops over the leaves in the tree, setting all dependencies
 func (t *Tree) Grow() {
+
+	// Loop over the leaves and resolve their dependencies
 	for _, leaf := range t.orderedLeaves {
 
 		// Resolve the dependencies for the leaf
@@ -45,7 +47,14 @@ func (t *Tree) Grow() {
 			}
 		}
 	}
+
+	// Make sure all dependencies are resolved
 	t.checkUnresolved()
+
+	// Loop over the leaves again and call PostConstruct
+	for _, leaf := range t.orderedLeaves {
+		leaf.callPostConstruct()
+	}
 }
 
 // GetLeaf gets a leaf in the tree by name


### PR DESCRIPTION
Fixes some issues with nested dependencies and postConstruct